### PR TITLE
Make GameplayDebugger dependency public

### DIFF
--- a/InworldAI/Source/InworldAIIntegration/InworldAIIntegration.Build.cs
+++ b/InworldAI/Source/InworldAIIntegration/InworldAIIntegration.Build.cs
@@ -35,7 +35,7 @@ public class InworldAIIntegration : ModuleRules
 
         if (Target.bBuildDeveloperTools || (Target.Configuration != UnrealTargetConfiguration.Shipping && Target.Configuration != UnrealTargetConfiguration.Test))
         {
-            PrivateDependencyModuleNames.Add("GameplayDebugger");
+            PublicDependencyModuleNames.Add("GameplayDebugger");
             PrivateDefinitions.Add("INWORLD_DEBUGGER_SLOT=5");
         }
 


### PR DESCRIPTION
if including headers with WITH_GAMEPLAY_DEBUGGER, this module needs to be public since it exists publicly