### PR TITLE
Inworld studio as tool menu

### DIFF
--- a/InworldAI/Source/InworldAIEditor/InworldAIEditor.Build.cs
+++ b/InworldAI/Source/InworldAIEditor/InworldAIEditor.Build.cs
@@ -38,6 +38,7 @@ public class InworldAIEditor : ModuleRules
                 "UMGEditor",
                 "Blutility",
                 "UMG",
+                "WorkspaceMenuStructure",
             }
             );
     }

--- a/InworldAI/Source/InworldAIEditor/Private/InworldAIEditorSettings.cpp
+++ b/InworldAI/Source/InworldAIEditor/Private/InworldAIEditorSettings.cpp
@@ -24,4 +24,6 @@ UInworldAIEditorSettings::UInworldAIEditorSettings(const FObjectInitializer& Obj
 	InworldCharacterComponent = UInworldCharacterComponent::StaticClass();
 	CharacterPlaybacks = { UInworldCharacterPlaybackAudio::StaticClass() };
 	OtherCharacterComponents = { UAudioComponent::StaticClass() };
+
+	InworldStudioWidget = "/InworldAI/StudioWidget/InworldStudioWidget.InworldStudioWidget";
 }

--- a/InworldAI/Source/InworldAIEditor/Public/InworldAIEditorModule.h
+++ b/InworldAI/Source/InworldAIEditor/Public/InworldAIEditorModule.h
@@ -12,6 +12,7 @@
 #include "ContentBrowserDelegates.h"
 #include "InworldStudioTypes.h"
 #include "UnrealEdMisc.h"
+#include "Blueprint/UserWidget.h"
 #include "InworldEditorUtilityWidget.h"
 
 INWORLDAIEDITOR_API DECLARE_LOG_CATEGORY_EXTERN(LogInworldAIEditor, Log, All);

--- a/InworldAI/Source/InworldAIEditor/Public/InworldAIEditorModule.h
+++ b/InworldAI/Source/InworldAIEditor/Public/InworldAIEditorModule.h
@@ -47,15 +47,13 @@ public:
 	}
 
 private:
+	TSharedRef<SDockTab> CreateInworldStudioTab(const FSpawnTabArgs& Args);
+
 	void AssetExtenderFunc(FMenuBuilder& MenuBuilder, const TArray<FAssetData> SelectedAssets);
 	TSharedRef<FExtender> OnExtendAssetSelectionMenu(const TArray<FAssetData>& SelectedAssets);
 
 	static bool CanSetupAssetAsInworldPlayer(const FAssetData& AssetData);
 	static void SetupAssetAsInworldPlayer(const FAssetData& AssetData);
-
-	void OpenInworldStudioWidget(TSharedPtr<SWindow>, bool);
-
-	FDelegateHandle OpenInworldStudioWidgetDelHandle;
 
 	FInworldStudioUserData StudioData;
 	FInworldEditorUtilityWidgetState StudioWidgetState;

--- a/InworldAI/Source/InworldAIEditor/Public/InworldAIEditorModule.h
+++ b/InworldAI/Source/InworldAIEditor/Public/InworldAIEditorModule.h
@@ -11,6 +11,7 @@
 #include "Modules/ModuleManager.h"
 #include "ContentBrowserDelegates.h"
 #include "InworldStudioTypes.h"
+#include "UnrealEdMisc.h"
 #include "InworldEditorUtilityWidget.h"
 
 INWORLDAIEDITOR_API DECLARE_LOG_CATEGORY_EXTERN(LogInworldAIEditor, Log, All);
@@ -48,6 +49,8 @@ public:
 
 private:
 	TSharedRef<SDockTab> CreateInworldStudioTab(const FSpawnTabArgs& Args);
+	TSharedRef<SWidget> CreateInworldStudioWidget();
+	void OnLevelEditorMapChanged(UWorld* World, EMapChangeType MapChangeType);
 
 	void AssetExtenderFunc(FMenuBuilder& MenuBuilder, const TArray<FAssetData> SelectedAssets);
 	TSharedRef<FExtender> OnExtendAssetSelectionMenu(const TArray<FAssetData>& SelectedAssets);
@@ -87,4 +90,9 @@ private:
 	};
 
 	FAssetActionMenu AssetActionMenu;
+
+	TWeakPtr<SDockTab> InworldStudioTab;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UUserWidget> InworldStudioUMGWidget;
 };

--- a/InworldAI/Source/InworldAIEditor/Public/InworldAIEditorModule.h
+++ b/InworldAI/Source/InworldAIEditor/Public/InworldAIEditorModule.h
@@ -93,7 +93,5 @@ private:
 	FAssetActionMenu AssetActionMenu;
 
 	TWeakPtr<SDockTab> InworldStudioTab;
-
-	UPROPERTY(Transient)
-	TObjectPtr<UUserWidget> InworldStudioUMGWidget;
+	UUserWidget* InworldStudioUMGWidget;
 };

--- a/InworldAI/Source/InworldAIEditor/Public/InworldAIEditorSettings.h
+++ b/InworldAI/Source/InworldAIEditor/Public/InworldAIEditorSettings.h
@@ -40,4 +40,8 @@ public:
 
 	UPROPERTY(EditAnywhere, Category = "Character")
 	TArray<TSubclassOf<UActorComponent>> OtherCharacterComponents;
+
+public:
+	UPROPERTY(config, VisibleAnywhere, Category = "Studio")
+	FSoftObjectPath InworldStudioWidget;
 };


### PR DESCRIPTION
[CORE-4061] [CORE-3971] Add Inworld Studio Widget as toolbar item
makes it easier to find, and fixes issues with rebooting editor while open failing to restore it
![image](https://github.com/inworld-ai/inworld-unreal-sdk/assets/6900799/cdbdf65d-2486-423d-bd5e-1c7f022ff1e5)


[CORE-4061]: https://inworldai.atlassian.net/browse/CORE-4061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-3971]: https://inworldai.atlassian.net/browse/CORE-3971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ