### PR TITLE
Remove INWORLD_DEBUGGER_SLOT, fix GameplayDebugger

### DIFF
--- a/InworldAI/Source/InworldAIIntegration/InworldAIIntegration.Build.cs
+++ b/InworldAI/Source/InworldAIIntegration/InworldAIIntegration.Build.cs
@@ -53,11 +53,7 @@ public class InworldAIIntegration : ModuleRules
             //PrivateDefinitions.Add("INWORLD_PIXEL_STREAMING=1");
         }
 
-        if (Target.bBuildDeveloperTools || (Target.Configuration != UnrealTargetConfiguration.Shipping && Target.Configuration != UnrealTargetConfiguration.Test))
-        {
-            PublicDependencyModuleNames.Add("GameplayDebugger");
-            PrivateDefinitions.Add("INWORLD_DEBUGGER_SLOT=5");
-        }
+        SetupGameplayDebuggerSupport(Target);
 
     }
 }

--- a/InworldAI/Source/InworldAIIntegration/Private/InworldAIIntegrationModule.cpp
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldAIIntegrationModule.cpp
@@ -7,7 +7,7 @@
 
 #include "InworldAIIntegrationModule.h"
 
-#if defined(WITH_GAMEPLAY_DEBUGGER) && defined(INWORLD_DEBUGGER_SLOT)
+#if defined(WITH_GAMEPLAY_DEBUGGER) && WITH_GAMEPLAY_DEBUGGER
 #include "GameplayDebugger.h"
 #include "InworldGameplayDebuggerCategory.h"
 #endif // WITH_GAMEPLAY_DEBUGGER
@@ -19,9 +19,9 @@ DEFINE_LOG_CATEGORY(LogInworldAIIntegration);
 void FInworldAIIntegrationModule::StartupModule()
 {
 	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
-#if defined(WITH_GAMEPLAY_DEBUGGER) && defined(INWORLD_DEBUGGER_SLOT)
+#if defined(WITH_GAMEPLAY_DEBUGGER) && WITH_GAMEPLAY_DEBUGGER
 	IGameplayDebugger& GameplayDebuggerModule = IGameplayDebugger::Get();
-	GameplayDebuggerModule.RegisterCategory("Inworld", IGameplayDebugger::FOnGetCategory::CreateStatic(&FInworldGameplayDebuggerCategory::MakeInstance), EGameplayDebuggerCategoryState::Disabled, INWORLD_DEBUGGER_SLOT);
+	GameplayDebuggerModule.RegisterCategory("Inworld", IGameplayDebugger::FOnGetCategory::CreateStatic(&FInworldGameplayDebuggerCategory::MakeInstance), EGameplayDebuggerCategoryState::Disabled);
 	GameplayDebuggerModule.NotifyCategoriesChanged();
 #endif
 }
@@ -30,7 +30,7 @@ void FInworldAIIntegrationModule::ShutdownModule()
 {
 	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
 	// we call this function before unloading the module.
-#if defined(WITH_GAMEPLAY_DEBUGGER) && defined(INWORLD_DEBUGGER_SLOT)
+#if defined(WITH_GAMEPLAY_DEBUGGER) && WITH_GAMEPLAY_DEBUGGER
 	if (IGameplayDebugger::IsAvailable())
 	{
 		IGameplayDebugger& GameplayDebuggerModule = IGameplayDebugger::Get();

--- a/InworldAI/Source/InworldAIIntegration/Private/InworldGameplayDebuggerCategory.cpp
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldGameplayDebuggerCategory.cpp
@@ -5,7 +5,7 @@
  * that can be found in the LICENSE.md file or at https://www.inworld.ai/sdk-license
  */
 
-#ifdef WITH_GAMEPLAY_DEBUGGER
+#if defined(WITH_GAMEPLAY_DEBUGGER) && WITH_GAMEPLAY_DEBUGGER == 1
 
 #include "InworldGameplayDebuggerCategory.h"
 #include "InworldApi.h"
@@ -15,7 +15,6 @@
 #include "InworldPlayerComponent.h"
 
 #include "UObject/UObjectIterator.h"
-//#include "NDK/Utils/Log.h"
 
 FInworldGameplayDebuggerCategory::FInworldGameplayDebuggerCategory()
 {
@@ -239,4 +238,4 @@ void FInworldGameplayDebuggerCategory::FPlayerRepData::Serialize(FArchive& Ar)
 	Ar << bServerCapturingVoice;
 }
 
-#endif // WITH_GAMEPLAY_DEBUGGER
+#endif // defined(WITH_GAMEPLAY_DEBUGGER) && WITH_GAMEPLAY_DEBUGGER == 1

--- a/InworldAI/Source/InworldAIIntegration/Private/InworldGameplayDebuggerCategory.h
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldGameplayDebuggerCategory.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#ifdef WITH_GAMEPLAY_DEBUGGER
+#if defined(WITH_GAMEPLAY_DEBUGGER) && WITH_GAMEPLAY_DEBUGGER == 1
 
 #include "GameplayDebuggerCategory.h"
 
@@ -66,4 +66,4 @@ protected:
 	FRepData DataPack;
 };
 
-#endif // WITH_GAMEPLAY_DEBUGGER
+#endif // defined(WITH_GAMEPLAY_DEBUGGER) && WITH_GAMEPLAY_DEBUGGER == 1

--- a/InworldAI/Source/InworldAIIntegration/Public/InworldApi.h
+++ b/InworldAI/Source/InworldAIIntegration/Public/InworldApi.h
@@ -17,7 +17,6 @@
 #include "InworldPackets.h"
 #include "InworldComponentInterface.h"
 
-#include "InworldGameplayDebuggerCategory.h"
 #include "InworldApi.generated.h"
 
 namespace Inworld
@@ -239,5 +238,7 @@ private:
 
 	bool bCharactersInitialized = false;
 
+#if defined(WITH_GAMEPLAY_DEBUGGER) && WITH_GAMEPLAY_DEBUGGER == 1
 	friend class FInworldGameplayDebuggerCategory;
+#endif
 };

--- a/InworldAI/Source/InworldAIIntegration/Public/InworldCharacterComponent.h
+++ b/InworldAI/Source/InworldAIIntegration/Public/InworldCharacterComponent.h
@@ -17,7 +17,6 @@
 #include "InworldEnums.h"
 #include "InworldPackets.h"
 #include "InworldSockets.h"
-#include "InworldGameplayDebuggerCategory.h"
 
 #include "Containers/Queue.h"
 
@@ -249,5 +248,7 @@ private:
 	
 	FString GivenName;
 
+#if defined(WITH_GAMEPLAY_DEBUGGER) && WITH_GAMEPLAY_DEBUGGER == 1
 	friend class FInworldGameplayDebuggerCategory;
+#endif
 };

--- a/InworldAI/Source/InworldAIIntegration/Public/InworldPlayerAudioCaptureComponent.h
+++ b/InworldAI/Source/InworldAIIntegration/Public/InworldPlayerAudioCaptureComponent.h
@@ -11,7 +11,6 @@
 #include "AudioCaptureCore.h"
 #include "AudioDevice.h"
 #include "Containers/ContainerAllocationPolicies.h"
-#include "InworldGameplayDebuggerCategory.h"
 
 #include "InworldPlayerAudioCaptureComponent.generated.h"
 
@@ -143,5 +142,7 @@ private:
 
     } PlayerAudioTarget;
 
+#if defined(WITH_GAMEPLAY_DEBUGGER) && WITH_GAMEPLAY_DEBUGGER == 1
     friend class FInworldGameplayDebuggerCategory;
+#endif
 };

--- a/InworldAI/Source/InworldAIIntegration/Public/InworldPlayerComponent.h
+++ b/InworldAI/Source/InworldAIIntegration/Public/InworldPlayerComponent.h
@@ -9,7 +9,6 @@
 
 #include "CoreMinimal.h"
 #include "InworldCharacterComponent.h"
-#include "InworldGameplayDebuggerCategory.h"
 
 #include "InworldPlayerComponent.generated.h"
 
@@ -81,5 +80,7 @@ private:
 	UPROPERTY(ReplicatedUsing = OnRep_TargetCharacterAgentId)
 	FString TargetCharacterAgentId;
 
-	friend class FInworldGameplayDebuggerCategory;
+#if defined(WITH_GAMEPLAY_DEBUGGER) && WITH_GAMEPLAY_DEBUGGER == 1
+    friend class FInworldGameplayDebuggerCategory;
+#endif
 };


### PR DESCRIPTION
Remove INWORLD_DEBUGGER_SLOT, order not guaranteed but won't conflict and need change in build.cs file Use SetupGameplayDebuggerSupport function in build.cs, fixup #ifdefs for editor/shipping builds. Since SetupGameplayDebuggerSupport by default adds as private, and always defines WITH_GAMEPLAY_DEBUGGER=0 there are issues checking with #ifdef, also need to check if 1/0. Making dep private is preferred, so made the debugger category for inworld private and removed header from public headers.