### PR TITLE
fix audio with mute state

### DIFF
--- a/InworldAI/Source/InworldAIIntegration/Private/InworldPlayerAudioCaptureComponent.cpp
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldPlayerAudioCaptureComponent.cpp
@@ -285,16 +285,28 @@ void UInworldPlayerAudioCaptureComponent::EvaluateVoiceCapture()
     {
         const bool bIsMicHot = !bMuted;
         const bool bIsWorldPlaying = !GetWorld()->IsPaused();
-        const bool bHasTargetCharacter = PlayerAudioTarget.AgentIds.Num() != 0;
+        const bool bHasTargetCharacter = !PlayerAudioTarget.DesiredAgentIds.IsEmpty();
         const bool bHasActiveInworldSession = InworldSubsystem.IsValid() && (InworldSubsystem->GetConnectionState() == EInworldConnectionState::Connected || InworldSubsystem->GetConnectionState() == EInworldConnectionState::Reconnecting);
 
         const bool bShouldCaptureVoice = bIsMicHot && bIsWorldPlaying && bHasTargetCharacter && bHasActiveInworldSession;
 
-        if (bShouldCaptureVoice != bServerCapturingVoice)
+        if (bShouldCaptureVoice && bServerCapturingVoice && (PlayerAudioTarget.DesiredAgentIds != PlayerAudioTarget.ActiveAgentIds))
+        {
+            InworldSubsystem->StopAudioSessionMultiAgent(PlayerAudioTarget.ActiveAgentIds);
+            InworldSubsystem->StartAudioSessionMultiAgent(PlayerAudioTarget.DesiredAgentIds, GetOwner());
+            PlayerAudioTarget.ActiveAgentIds = PlayerAudioTarget.DesiredAgentIds;
+        }
+        else if (bShouldCaptureVoice != bServerCapturingVoice)
         {
             if (bShouldCaptureVoice)
             {
-                InworldSubsystem->StartAudioSessionMultiAgent(PlayerAudioTarget.AgentIds, GetOwner());
+                InworldSubsystem->StartAudioSessionMultiAgent(PlayerAudioTarget.DesiredAgentIds, GetOwner());
+                PlayerAudioTarget.ActiveAgentIds = PlayerAudioTarget.DesiredAgentIds;
+            }
+            else
+            {
+                InworldSubsystem->StopAudioSessionMultiAgent(PlayerAudioTarget.ActiveAgentIds);
+                PlayerAudioTarget.ActiveAgentIds.Empty();
             }
 
             bServerCapturingVoice = bShouldCaptureVoice;
@@ -410,15 +422,15 @@ void UInworldPlayerAudioCaptureComponent::StopCapture()
 
 void UInworldPlayerAudioCaptureComponent::Server_ProcessVoiceCaptureChunk_Implementation(FPlayerVoiceCaptureInfoRep PlayerVoiceCaptureInfo)
 {
-    if (PlayerAudioTarget.AgentIds.Num() != 0)
+    if (!PlayerAudioTarget.ActiveAgentIds.IsEmpty())
     {
         if (bEnableAEC)
         {
-            InworldSubsystem->SendAudioDataMessageWithAEC(PlayerAudioTarget.AgentIds, PlayerVoiceCaptureInfo.MicSoundData, PlayerVoiceCaptureInfo.OutputSoundData);
+            InworldSubsystem->SendAudioDataMessageWithAEC(PlayerAudioTarget.ActiveAgentIds, PlayerVoiceCaptureInfo.MicSoundData, PlayerVoiceCaptureInfo.OutputSoundData);
         }
         else
         {
-            InworldSubsystem->SendAudioDataMessage(PlayerAudioTarget.AgentIds, PlayerVoiceCaptureInfo.MicSoundData);
+            InworldSubsystem->SendAudioDataMessage(PlayerAudioTarget.ActiveAgentIds, PlayerVoiceCaptureInfo.MicSoundData);
         }
     }
 }
@@ -431,37 +443,21 @@ bool UInworldPlayerAudioCaptureComponent::IsLocallyControlled() const
 
 void UInworldPlayerAudioCaptureComponent::OnPlayerTargetSet(UInworldCharacterComponent* Target)
 {
-    int32 Idx;
-    if (PlayerAudioTarget.AgentIds.Find(Target->GetAgentId(), Idx))
+    if (PlayerAudioTarget.DesiredAgentIds.Contains(Target->GetAgentId()))
     {
         return;
     }
-
-    if (bServerCapturingVoice)
-    {
-        InworldSubsystem->StopAudioSessionMultiAgent(PlayerAudioTarget.AgentIds);
-        bServerCapturingVoice = false;
-    }
-
-    PlayerAudioTarget.AgentIds.Add(Target->GetAgentId());
+    PlayerAudioTarget.DesiredAgentIds.Add(Target->GetAgentId());
     EvaluateVoiceCapture();
 }
 
 void UInworldPlayerAudioCaptureComponent::OnPlayerTargetClear(UInworldCharacterComponent* Target)
 {
-    int32 Idx;
-    if (!PlayerAudioTarget.AgentIds.Find(Target->GetAgentId(), Idx))
+    if (!PlayerAudioTarget.DesiredAgentIds.Contains(Target->GetAgentId()))
     {
         return;
     }
-
-    if (bServerCapturingVoice)
-    {
-        InworldSubsystem->StopAudioSessionMultiAgent(PlayerAudioTarget.AgentIds);
-        bServerCapturingVoice = false;
-    }
-
-    PlayerAudioTarget.AgentIds.RemoveAt(Idx);
+    PlayerAudioTarget.DesiredAgentIds.RemoveSingle(Target->GetAgentId());
     EvaluateVoiceCapture();
 }
 

--- a/InworldAI/Source/InworldAIIntegration/Public/InworldPlayerAudioCaptureComponent.h
+++ b/InworldAI/Source/InworldAIIntegration/Public/InworldPlayerAudioCaptureComponent.h
@@ -137,7 +137,8 @@ private:
 
     struct FPlayerAudioTarget
     {
-        TArray<FString> AgentIds;
+        TArray<FString> ActiveAgentIds;
+        TArray<FString> DesiredAgentIds;
 
     } PlayerAudioTarget;
 


### PR DESCRIPTION
Currently there is issue with multi agent audio component with using set muted for push to talk let evaluation of audio state be set in EvaluateAudio where it can take all factors contributing to if audio should be on or off instead of directly inside targeting logic maintain desired list of targets, and only swap when changing and audio is active, otherwise just modify the cached list until other conditions are met