### PR TITLE
5.4 packaging fixes

### DIFF
--- a/InworldAI/Source/InworldAIClient/Private/InworldPacketTranslator.h
+++ b/InworldAI/Source/InworldAIClient/Private/InworldPacketTranslator.h
@@ -7,11 +7,11 @@
 
 #pragma once
 
+#include "InworldPackets.h"
+
 THIRD_PARTY_INCLUDES_START
 #include "Packets.h"
 THIRD_PARTY_INCLUDES_END
-
-#include "InworldPackets.h"
 
 class InworldPacketTranslator : public Inworld::PacketVisitor
 {

--- a/InworldAI/Source/InworldAIEditor/Private/InworldEditorApi.cpp
+++ b/InworldAI/Source/InworldAIEditor/Private/InworldEditorApi.cpp
@@ -5,8 +5,6 @@
  * that can be found in the LICENSE.md file or at https://www.inworld.ai/sdk-license
  */
 
-#pragma once
-
 #include "InworldEditorApi.h"
 #include "Kismet/GameplayStatics.h"
 #include "InworldCharacterComponent.h"

--- a/InworldAI/Source/InworldAIEditor/Private/Studio/InworldStudioWidget.cpp
+++ b/InworldAI/Source/InworldAIEditor/Private/Studio/InworldStudioWidget.cpp
@@ -5,8 +5,6 @@
  * that can be found in the LICENSE.md file or at https://www.inworld.ai/sdk-license
  */
 
-#pragma once
-
 #include "Studio/InworldStudioWidget.h"
 #include "InworldAIEditorModule.h"
 

--- a/InworldAI/Source/InworldAIIntegration/Private/InworldApi.cpp
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldApi.cpp
@@ -5,8 +5,6 @@
  * that can be found in the LICENSE.md file or at https://www.inworld.ai/sdk-license
  */
 
-#pragma once
-
 #include "InworldApi.h"
 #include "InworldAIIntegrationModule.h"
 #include "InworldComponentInterface.h"

--- a/InworldAI/Source/InworldAIIntegration/Private/InworldCharacterAudioComponent.cpp
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldCharacterAudioComponent.cpp
@@ -12,6 +12,9 @@
 #include "Sound/SoundWave.h"
 #include "TimerManager.h"
 
+#include <GameFramework/Actor.h>
+#include <Engine/World.h>
+
 void UInworldCharacterAudioComponent::BeginPlay()
 {
 	Super::BeginPlay();

--- a/InworldAI/Source/InworldAIIntegration/Private/InworldCharacterPlayback.cpp
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldCharacterPlayback.cpp
@@ -7,6 +7,7 @@
 
 #include "InworldCharacterPlayback.h"
 #include "InworldCharacterComponent.h"
+#include <GameFramework/Actor.h>
 
 void UInworldCharacterPlayback::BeginPlay_Implementation() {}
 void UInworldCharacterPlayback::EndPlay_Implementation() {}

--- a/InworldAI/Source/InworldAIIntegration/Private/InworldCharacterPlaybackAudio.cpp
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldCharacterPlaybackAudio.cpp
@@ -14,6 +14,8 @@
 #include "Sound/SoundWave.h"
 #include "TimerManager.h"
 #include <Components/AudioComponent.h>
+#include <GameFramework/Actor.h>
+#include <Engine/World.h>
 
 void UInworldCharacterPlaybackAudio::BeginPlay_Implementation()
 {

--- a/InworldAI/Source/InworldAIIntegration/Private/InworldCharacterPlaybackTrigger.cpp
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldCharacterPlaybackTrigger.cpp
@@ -7,6 +7,8 @@
 
 #include "InworldCharacterPlaybackTrigger.h"
 #include "InworldApi.h"
+#include <GameFramework/Actor.h>
+#include <Engine/World.h>
 
 void UInworldCharacterPlaybackTrigger::OnCharacterTrigger_Implementation(const FCharacterMessageTrigger& Message)
 {

--- a/InworldAI/Source/InworldAIIntegration/Private/InworldGameplayDebuggerCategory.cpp
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldGameplayDebuggerCategory.cpp
@@ -15,6 +15,7 @@
 #include "InworldPlayerAudioCaptureComponent.h"
 #include "InworldPlayerComponent.h"
 
+#include <GameFramework/PlayerController.h>
 #include "UObject/UObjectIterator.h"
 
 FInworldGameplayDebuggerCategory::FInworldGameplayDebuggerCategory()

--- a/InworldAI/Source/InworldAIIntegration/Private/InworldPlayerAudioCaptureComponent.cpp
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldPlayerAudioCaptureComponent.cpp
@@ -33,6 +33,7 @@
 #include <Algo/Accumulate.h>
 #include <Net/UnrealNetwork.h>
 #include <GameFramework/PlayerController.h>
+#include <Engine/World.h>
 
 constexpr uint32 gSamplesPerSec = 16000;
 constexpr uint32 gNumChannels = 1;

--- a/InworldAI/Source/InworldAIIntegration/Public/InworldCharacterPlayback.h
+++ b/InworldAI/Source/InworldAIIntegration/Public/InworldCharacterPlayback.h
@@ -123,7 +123,7 @@ protected:
 	}
 
 	TWeakObjectPtr<AActor> OwnerActor;
-	TWeakObjectPtr<class UInworldCharacterComponent> CharacterComponent;
+	TWeakObjectPtr<UInworldCharacterComponent> CharacterComponent;
 
 	FInworldCharacterMessageQueueLockHandle CharacterMessageQueueLockHandle;
 };

--- a/build-scripts/win-gen-marketplace.bat
+++ b/build-scripts/win-gen-marketplace.bat
@@ -1,5 +1,6 @@
 python marketplace-util.py -p Win64 -u 5.1 -b False
 python marketplace-util.py -p Win64 -u 5.2 -b False
 python marketplace-util.py -p Win64 -u 5.3 -b False
+python marketplace-util.py -p Win64 -u 5.4 -b False
 
 pause


### PR DESCRIPTION
missing headers when building UE 5.4 marketplace package, and headers out of order causing windows lib errors