### PR TITLE
conversation participant or observer

### DIFF
--- a/InworldAI/Source/InworldAIIntegration/Private/InworldPlayerAudioCaptureComponent.cpp
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldPlayerAudioCaptureComponent.cpp
@@ -297,12 +297,13 @@ void UInworldPlayerAudioCaptureComponent::EvaluateVoiceCapture()
     {
         const bool bIsMicHot = !bMuted;
         const bool bIsWorldPlaying = !GetWorld()->IsPaused();
+        const bool bIsParticipating = InworldPlayer->IsConversationParticipant();
         const bool bHasConversation = !InworldPlayer->GetConversationId().IsEmpty();
         UInworldSession* InworldSession = InworldPlayer->GetSession();
         const EInworldConnectionState ConnectionState = InworldSession ? InworldSession->GetConnectionState() : EInworldConnectionState::Idle;
         const bool bHasActiveInworldSession = InworldSession && InworldSession->IsLoaded() && (ConnectionState == EInworldConnectionState::Connected || ConnectionState == EInworldConnectionState::Reconnecting);
 
-        const bool bShouldCaptureVoice = bIsMicHot && bIsWorldPlaying && bHasConversation && bHasActiveInworldSession;
+        const bool bShouldCaptureVoice = bIsMicHot && bIsWorldPlaying && bIsParticipating && bHasConversation && bHasActiveInworldSession;
 
         if (bShouldCaptureVoice != bServerCapturingVoice)
         {

--- a/InworldAI/Source/InworldAIIntegration/Private/InworldPlayerComponent.cpp
+++ b/InworldAI/Source/InworldAIIntegration/Private/InworldPlayerComponent.cpp
@@ -79,6 +79,16 @@ void UInworldPlayerComponent::UninitializeComponent()
     }
 }
 
+void UInworldPlayerComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (GetOwnerRole() == ROLE_Authority)
+    {
+        InworldPlayer->SetConversationParticipation(bConversationParticipant);
+    }
+}
+
 void UInworldPlayerComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
@@ -100,6 +110,22 @@ bool UInworldPlayerComponent::ReplicateSubobjects(UActorChannel* Channel, FOutBu
 
     return WroteSomething;
 #endif
+}
+
+void UInworldPlayerComponent::SetConversationParticipation(bool bParticipating)
+{
+    if (InworldPlayer->IsConversationParticipant() != bParticipating)
+    {
+        InworldPlayer->SetConversationParticipation(bParticipating);
+    }
+    bConversationParticipant = InworldPlayer->IsConversationParticipant();
+}
+
+void UInworldPlayerComponent::ContinueConversation()
+{
+    NO_PLAYER_RETURN(void())
+
+    InworldPlayer->SendTriggerToConversation(TEXT("inworld.conversation.next_turn"), {});
 }
 
 UInworldCharacterComponent* UInworldPlayerComponent::GetTargetInworldCharacter()
@@ -126,21 +152,14 @@ TArray<UInworldCharacterComponent*> UInworldPlayerComponent::GetTargetInworldCha
     return InworldCharacterComponents;
 }
 
-void UInworldPlayerComponent::ContinueMultiAgentConversation()
-{
-    NO_PLAYER_RETURN(void())
-
-    InworldPlayer->SendTriggerToConversation(TEXT("inworld.conversation.next_turn"), {});
-}
-
-void UInworldPlayerComponent::SetTargetInworldCharacter(UInworldCharacterComponent* Character)
+void UInworldPlayerComponent::AddTargetInworldCharacter(UInworldCharacterComponent* Character)
 {
     NO_PLAYER_RETURN(void())
 
     InworldPlayer->AddTargetCharacter(IInworldCharacterOwnerInterface::Execute_GetInworldCharacter(Character));
 }
 
-void UInworldPlayerComponent::ClearTargetInworldCharacter(UInworldCharacterComponent* Character)
+void UInworldPlayerComponent::RemoveTargetInworldCharacter(UInworldCharacterComponent* Character)
 {
     NO_PLAYER_RETURN(void())
 

--- a/InworldAI/Source/InworldAIIntegration/Public/InworldPlayer.h
+++ b/InworldAI/Source/InworldAIIntegration/Public/InworldPlayer.h
@@ -60,7 +60,12 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Player")
 	TScriptInterface<IInworldPlayerOwnerInterface> GetInworldPlayerOwner();
 
-	UFUNCTION(BlueprintCallable, Category = "Target")
+	UFUNCTION(BlueprintCallable, Category = "Participation")
+	void SetConversationParticipation(bool bParticipate);
+	UFUNCTION(BlueprintPure, Category = "Participation")
+	bool IsConversationParticipant() const { return bConversationParticipant; }
+
+	UFUNCTION(BlueprintPure, Category = "Target")
 	const TArray<UInworldCharacter*>& GetTargetCharacters() const { return TargetCharacters; }
 
 	UFUNCTION(BlueprintCallable, Category = "Target")
@@ -100,6 +105,9 @@ private:
 private:
 	UPROPERTY(Replicated)
 	UInworldSession* Session;
+
+	UPROPERTY(Replicated)
+	bool bConversationParticipant = true;
 
 	UPROPERTY(Replicated)
 	TArray<UInworldCharacter*> TargetCharacters;

--- a/InworldAI/Source/InworldAIIntegration/Public/InworldPlayerComponent.h
+++ b/InworldAI/Source/InworldAIIntegration/Public/InworldPlayerComponent.h
@@ -16,17 +16,6 @@
 class UInworldApiSubsystem;
 class UInworldCharacterComponent;
 
-USTRUCT()
-struct FInworldPlayerTargetCharacter
-{
-    GENERATED_BODY()
-
-	FDelegateHandle UnpossessedHandle;
-
-	UPROPERTY()
-	FString AgentId;
-};
-
 UCLASS(ClassGroup = (Inworld), meta = (BlueprintSpawnableComponent))
 class INWORLDAIINTEGRATION_API UInworldPlayerComponent : public UActorComponent, public IInworldPlayerOwnerInterface
 {
@@ -44,24 +33,33 @@ public:
     virtual void InitializeComponent() override;
     virtual void UninitializeComponent() override;
 
+    virtual void BeginPlay() override;
+
     virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
     virtual bool ReplicateSubobjects(UActorChannel* Channel, FOutBunch* Bunch, FReplicationFlags* RepFlags) override;
+
+    UFUNCTION(BlueprintCallable, Category = "Interaction")
+    void SetConversationParticipation(bool bParticipant);
+
+    UFUNCTION(BlueprintCallable, Category = "Interaction")
+    void ContinueConversation();
 
     UFUNCTION(BlueprintCallable, Category = "Interaction", meta = (Displayname = "GetTargetCharacter"))
     UInworldCharacterComponent* GetTargetInworldCharacter();
     UFUNCTION(BlueprintCallable, Category = "Interaction", meta = (Displayname = "GetTargetCharacters"))
     TArray<UInworldCharacterComponent*> GetTargetInworldCharacters();
 
-    UFUNCTION(BlueprintCallable, Category = "Interaction", meta = (DeprecatedFunction, DeprecationMessage = "Will be removed in next release."))
-    void ContinueMultiAgentConversation();
+    UFUNCTION(BlueprintCallable, Category = "Interaction", meta = (Displayname = "SetTargetCharacter", DeprecatedFunction, DeprecationMessage="Please use AddTargetCharacter"))
+    void SetTargetInworldCharacter(UInworldCharacterComponent* Character) { AddTargetInworldCharacter(Character); }
+    UFUNCTION(BlueprintCallable, Category = "Interaction", meta = (Displayname = "AddTargetCharacter"))
+    void AddTargetInworldCharacter(UInworldCharacterComponent* Character);
 
-    UFUNCTION(BlueprintCallable, Category = "Interaction", meta = (Displayname = "SetTargetCharacter"))
-    void SetTargetInworldCharacter(UInworldCharacterComponent* Character);
+    UFUNCTION(BlueprintCallable, Category = "Interaction", meta = (Displayname = "ClearTargetCharacter", DeprecatedFunction, DeprecationMessage = "Please use RemoveTargetCharacter"))
+    void ClearTargetInworldCharacter(UInworldCharacterComponent* Character) { RemoveTargetInworldCharacter(Character); }
+    UFUNCTION(BlueprintCallable, Category = "Interaction", meta = (Displayname = "RemoveTargetCharacter"))
+    void RemoveTargetInworldCharacter(UInworldCharacterComponent* Character);
 
-    UFUNCTION(BlueprintCallable, Category = "Interaction", meta = (Displayname = "ClearTargetCharacter"))
-    void ClearTargetInworldCharacter(UInworldCharacterComponent* Character);
-
-    UFUNCTION(BlueprintCallable, Category = "Interaction", meta = (Displayname = "ClearTargetCharacter"))
+    UFUNCTION(BlueprintCallable, Category = "Interaction", meta = (Displayname = "ClearAllTargetCharacters"))
     void ClearAllTargetInworldCharacters();
 
 	UFUNCTION(BlueprintCallable, Category = "Interaction")
@@ -90,6 +88,9 @@ private:
 
     UPROPERTY(Replicated)
     UInworldPlayer* InworldPlayer;
+
+    UPROPERTY(EditDefaultsOnly, Category = "Conversation")
+    bool bConversationParticipant = true;
 
 #if defined(WITH_GAMEPLAY_DEBUGGER) && WITH_GAMEPLAY_DEBUGGER
     friend class FInworldGameplayDebuggerCategory;


### PR DESCRIPTION
Add ability to configure if player is in conversation or not while targeting characters cleanup unused struct
update naming to Add/Remove instead of Set/Clear to better indicate a list over single
https://inworldai.atlassian.net/browse/INTG-1713