### PR TITLE
Check for microphone usage description

### DIFF
--- a/InworldAI/Source/InworldAIPlatform/Public/Apple/AppleAudioPermission.h
+++ b/InworldAI/Source/InworldAIPlatform/Public/Apple/AppleAudioPermission.h
@@ -30,6 +30,8 @@ typedef void (*Callback)(bool);
 
 -(int) getPermission
 {
+    if(nil == [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSMicrophoneUsageDescription"]) return -1;
+    
     switch([AVCaptureDevice authorizationStatusForMediaType : AVMediaTypeAudio])
     {
         case AVAuthorizationStatusAuthorized:


### PR DESCRIPTION
If NSMicrophoneUsageDescription is missing, Mac/iOS will force-exit the app.
Instead, check if our info.plist contains the description, if it doesn't, fail out early with signaling that we don't have permission for mic usage

https://inworldai.atlassian.net/browse/INTG-1711